### PR TITLE
DefaultCacheDir = ":PREFERRED_CACHE_HOME:/cointop"

### DIFF
--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -16,7 +16,7 @@ import (
 )
 
 // DefaultCacheDir ...
-var DefaultCacheDir = "/tmp"
+var DefaultCacheDir = ":PREFERRED_CACHE_HOME:/cointop"
 
 // FileCache ...
 type FileCache struct {


### PR DESCRIPTION
Per #179 use the platform-specific directory for cache by default. Works with "clean" now too, since #192 

```
$ ./bin/cointop clean
removing /Users/simonroberts/Library/Caches/cointop/fcache.636d9ebe.coingecko_allcoinsslugmap.1633224019
removing /Users/simonroberts/Library/Caches/cointop/fcache.636d9ebe.coingecko_globaldata_usd_1y.1633224018
removing /Users/simonroberts/Library/Caches/cointop/fcache.636d9ebe.coingecko_market_usd.1633224018
cointop cache has been cleaned
```
