### PR TITLE
Fix/coin link

### DIFF
--- a/cointop/list.go
+++ b/cointop/list.go
@@ -165,6 +165,7 @@ func (ct *Cointop) processCoins(coins []types.Coin) {
 					c.PercentChange1Y = cm.PercentChange1Y
 					c.LastUpdated = cm.LastUpdated
 					c.Favorite = cm.Favorite
+					c.Slug = cm.Slug
 				}
 			}
 

--- a/cointop/list.go
+++ b/cointop/list.go
@@ -8,8 +8,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var coinslock sync.Mutex
-var updatecoinsmux sync.Mutex
+var (
+	coinslock      sync.Mutex
+	updatecoinsmux sync.Mutex
+)
 
 // UpdateCoins updates coins view
 func (ct *Cointop) UpdateCoins() error {
@@ -110,6 +112,7 @@ func (ct *Cointop) processCoins(coins []types.Coin) {
 			PercentChange30D: v.PercentChange30D,
 			PercentChange1Y:  v.PercentChange1Y,
 			LastUpdated:      v.LastUpdated,
+			Slug:             v.Slug,
 		})
 		if ilast != nil {
 			last, _ := ilast.(*Coin)

--- a/cointop/table.go
+++ b/cointop/table.go
@@ -197,6 +197,15 @@ func (ct *Cointop) RowLink() string {
 		return ""
 	}
 
+	// TODO: Can remove this one after some releases
+	// because it is a way to force old client refresh coin to have a slug
+	if coin.Slug == "" {
+		if err := ct.UpdateCoin(coin); err != nil {
+			log.Debugf("RowLink() Update coin got err %s", err.Error())
+			return ""
+		}
+	}
+
 	return ct.api.CoinLink(coin.Slug)
 }
 

--- a/cointop/table.go
+++ b/cointop/table.go
@@ -197,7 +197,7 @@ func (ct *Cointop) RowLink() string {
 		return ""
 	}
 
-	return ct.api.CoinLink(coin.Name)
+	return ct.api.CoinLink(coin.Slug)
 }
 
 // RowLinkShort returns a shortened version of the row url link

--- a/pkg/api/impl/coingecko/coingecko.go
+++ b/pkg/api/impl/coingecko/coingecko.go
@@ -267,15 +267,13 @@ func (s *Service) Price(name string, convert string) (float64, error) {
 	return 0, ErrNotFound
 }
 
-// CoinLink returns the URL link for the coin
-func (s *Service) CoinLink(name string) string {
-	ID := s.coinNameToID(name)
-	return fmt.Sprintf("https://www.coingecko.com/en/coins/%s", ID)
+func (s *Service) CoinLink(slug string) string {
+	// slug is API ID of coin
+	return fmt.Sprintf("https://www.coingecko.com/en/coins/%s", slug)
 }
 
 // SupportedCurrencies returns a list of supported currencies
 func (s *Service) SupportedCurrencies() []string {
-
 	// keep these in alphabetical order
 	return []string{
 		"AED",
@@ -462,6 +460,7 @@ func (s *Service) getPaginatedCoinData(convert string, offset int, names []strin
 				PercentChange1Y:  util.FormatPercentChange(percentChange1Y),
 				Volume24H:        util.FormatVolume(item.TotalVolume),
 				LastUpdated:      util.FormatLastUpdated(item.LastUpdated),
+				Slug:             item.ID,
 			})
 		}
 	}

--- a/pkg/api/impl/coingecko/coingecko.go
+++ b/pkg/api/impl/coingecko/coingecko.go
@@ -460,7 +460,7 @@ func (s *Service) getPaginatedCoinData(convert string, offset int, names []strin
 				PercentChange1Y:  util.FormatPercentChange(percentChange1Y),
 				Volume24H:        util.FormatVolume(item.TotalVolume),
 				LastUpdated:      util.FormatLastUpdated(item.LastUpdated),
-				Slug:             item.ID,
+				Slug:             util.FormatSlug(item.ID),
 			})
 		}
 	}

--- a/pkg/api/impl/coinmarketcap/coinmarketcap.go
+++ b/pkg/api/impl/coinmarketcap/coinmarketcap.go
@@ -77,6 +77,7 @@ func (s *Service) getPaginatedCoinData(convert string, offset int) ([]apitypes.C
 		}
 
 		ret = append(ret, apitypes.Coin{
+			// TODO: Fix ID
 			ID:               util.FormatID(v.Name),
 			Name:             util.FormatName(v.Name),
 			Symbol:           util.FormatSymbol(v.Symbol),

--- a/pkg/api/impl/coinmarketcap/coinmarketcap.go
+++ b/pkg/api/impl/coinmarketcap/coinmarketcap.go
@@ -334,7 +334,7 @@ func (s *Service) Price(name string, convert string) (float64, error) {
 
 // CoinLink returns the URL link for the coin
 func (s *Service) CoinLink(slug string) string {
-	return fmt.Sprintf("https://coinmarketcap.com/currencies/%s", slug)
+	return fmt.Sprintf("https://coinmarketcap.com/currencies/%s/", slug)
 }
 
 // SupportedCurrencies returns a list of supported currencies

--- a/pkg/api/impl/coinmarketcap/coinmarketcap.go
+++ b/pkg/api/impl/coinmarketcap/coinmarketcap.go
@@ -90,6 +90,7 @@ func (s *Service) getPaginatedCoinData(convert string, offset int) ([]apitypes.C
 			PercentChange7D:  util.FormatPercentChange(quote.PercentChange7D),
 			Volume24H:        util.FormatVolume(v.Quote[convert].Volume24H),
 			LastUpdated:      util.FormatLastUpdated(v.LastUpdated),
+			Slug:             util.FormatSlug(v.Slug),
 		})
 	}
 	return ret, nil
@@ -297,7 +298,6 @@ func (s *Service) GetGlobalMarketData(convert string) (apitypes.GlobalMarketData
 	market, err := s.client.GlobalMetrics.LatestQuotes(&cmc.QuoteOptions{
 		Convert: convert,
 	})
-
 	if err != nil {
 		return ret, err
 	}
@@ -332,8 +332,7 @@ func (s *Service) Price(name string, convert string) (float64, error) {
 }
 
 // CoinLink returns the URL link for the coin
-func (s *Service) CoinLink(name string) string {
-	slug := util.NameToSlug(name)
+func (s *Service) CoinLink(slug string) string {
 	return fmt.Sprintf("https://coinmarketcap.com/currencies/%s", slug)
 }
 

--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -13,7 +13,7 @@ type Interface interface {
 	GetGlobalMarketData(convert string) (types.GlobalMarketData, error)
 	GetCoinData(name string, convert string) (types.Coin, error)
 	GetCoinDataBatch(names []string, convert string) ([]types.Coin, error)
-	CoinLink(name string) string
+	CoinLink(slug string) string
 	SupportedCurrencies() []string
 	Price(name string, convert string) (float64, error)
 	GetExchangeRate(convertFrom, convertTo string, cached bool) (float64, error) // I don't love this caching

--- a/pkg/api/types/types.go
+++ b/pkg/api/types/types.go
@@ -17,6 +17,8 @@ type Coin struct {
 	PercentChange30D float64 `json:"percentChange30D"`
 	PercentChange1Y  float64 `json:"percentChange1Y"`
 	LastUpdated      string  `json:"lastUpdated"`
+	// Slug uses to access the coin's info web page
+	Slug string `json:"slug"`
 }
 
 // GlobalMarketData struct

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -29,6 +29,10 @@ func FormatName(name string) string {
 	return name
 }
 
+func FormatSlug(slug string) string {
+	return slug
+}
+
 // FormatRank formats the rank value
 func FormatRank(rank interface{}) int {
 	switch v := rank.(type) {


### PR DESCRIPTION
Currently, some links couldn't be open correctly on one (or both) Coingecko, Coinmarketcap websites:
- **Doge**, **Buff Doge Coin**: the problem is about converting name to ID, also related to the old issue because the name of **Doge** (name: `Dogecoin`) is similar to the symbol of the **Buff Doge Coin** (symbol: `DOGECOIN`).
- **Travala.com**: coingecko supports **travala**/**travala.com** slug but the `CoinLink` method is using a regex to replace non Alpha numeric chars to dash. So the original name is "Travala.com" and the converted name is "travala-com" -> unable to use.
https://github.com/cointop-sh/cointop/blob/8b8db3bd13c366a9657434af71b61400e6b01ad9/pkg/api/util/util.go#L12-L15
shouldn't change the regex because it will impact to **yearn.finance** coin (it only works with "yearn-finance" slug on Coingecko).

Seems both Coingecko and Coinmarketcap supported slug, please see the below. This PR is about switching to use slug instead of name.

Coingecko supports `id`
```json
{
    "id": "concierge-io",
    "symbol": "ava",
    "name": "Travala.com",
    "image": "https://assets.coingecko.com/coins/images/3014/large/Travala.png?1558020611",
    "current_price": 2.77,
    "market_cap": 147501823,
    "market_cap_rank": 411,
    "fully_diluted_valuation": null,
    "total_volume": 7569293,
    "high_24h": 2.8,
    "low_24h": 2.71,
    "price_change_24h": 0.01135146,
    "price_change_percentage_24h": 0.41202,
    "market_cap_change_24h": 9243.35,
    "market_cap_change_percentage_24h": 0.00627,
    "circulating_supply": 53373082,
    "total_supply": 61383832,
    "max_supply": null,
    "ath": 6.45,
    "ath_change_percentage": -57.11379,
    "ath_date": "2021-04-14T07:24:28.788Z",
    "atl": 0.01218947,
    "atl_change_percentage": 22576.29765,
    "atl_date": "2019-02-27T00:00:00.000Z",
    "roi": {
        "times": 6.9040071307770114,
        "currency": "usd",
        "percentage": 690.4007130777012
    },
    "last_updated": "2021-11-13T12:54:15.485Z"
}
```
it is equivalent to `API id` on the UI 
![image](https://user-images.githubusercontent.com/3168632/141645113-445df9a6-ffd4-422f-9792-2c32e5688d7f.png)


Coinmarketcap supports `slug`
```json
{
    "id": 1,
    "name": "Bitcoin",
    "symbol": "BTC",
    "slug": "bitcoin",
    "cmc_rank": 5,
    "num_market_pairs": 500,
    "circulating_supply": 16950100,
    "total_supply": 16950100,
    "max_supply": 21000000,
    "last_updated": "2018-06-02T22:51:28.209Z",
    "date_added": "2013-04-28T00:00:00.000Z",
    "tags": [
        "mineable"
    ],
    "platform": null,
    "quote": {
        "USD": {
            "price": 9283.92,
            "volume_24h": 7155680000,
            "volume_change_24h": -0.152774,
            "percent_change_1h": -0.152774,
            "percent_change_24h": 0.518894,
            "percent_change_7d": 0.986573,
            "market_cap": 852164659250.2758,
            "market_cap_dominance": 51,
            "fully_diluted_market_cap": 952835089431.14,
            "last_updated": "2018-08-09T22:53:32.000Z"
        },
        "BTC": {
            "price": 1,
            "volume_24h": 772012,
            "volume_change_24h": 0,
            "percent_change_1h": 0,
            "percent_change_24h": 0,
            "percent_change_7d": 0,
            "market_cap": 17024600,
            "market_cap_dominance": 12,
            "fully_diluted_market_cap": 952835089431.14,
            "last_updated": "2018-08-09T22:53:32.000Z"
        }
    }
}
```