### PR TITLE
Fix panic due to using wrong value for key

### DIFF
--- a/cointop/coin.go
+++ b/cointop/coin.go
@@ -1,8 +1,6 @@
 package cointop
 
 import (
-	"errors"
-
 	log "github.com/sirupsen/logrus"
 )
 
@@ -106,12 +104,6 @@ func (ct *Cointop) UpdateCoin(coin *Coin) error {
 		return err
 	}
 
-	k, found := ct.State.allCoinsSlugMap.Load(coin.Name)
-	if !found {
-		log.Debugf("UpdateCoin() could not found coin %s in the slug map", coin.Name)
-		return errors.New("could not find coin index in allCoinsSlugMap")
-	}
-
 	coin = &Coin{
 		ID:               v.ID,
 		Name:             v.Name,
@@ -131,7 +123,7 @@ func (ct *Cointop) UpdateCoin(coin *Coin) error {
 		Slug:             v.Slug,
 	}
 
-	ct.State.allCoinsSlugMap.Store(k, coin)
+	ct.State.allCoinsSlugMap.Store(coin.Name, coin)
 
 	return nil
 }


### PR DESCRIPTION
Sorry for mistake caused by my previous CoinLink PR 😥
— Fix wrong key 
— Remove checking item in map due to redundant

Here is the panic log
```
panic: interface conversion: interface {} is *cointop.Coin, not string

goroutine 1 [running]:
github.com/cointop-sh/cointop/cointop.(*Cointop).UpdateTable.func1({0x11d7620, 0xc0001fea80}, {0x11d7620, 0xc000fd4380})
        D:/workspace/github.com/cointop-sh/cointop/cointop/table.go:69 +0x113
sync.(*Map).Range(0xc000252a18, 0xc0000a1898)
        C:/Users/quocv/scoop/apps/go/current/src/sync/map.go:346 +0x2aa
github.com/cointop-sh/cointop/cointop.(*Cointop).UpdateTable(0xc000268000)
        D:/workspace/github.com/cointop-sh/cointop/cointop/table.go:68 +0x90
github.com/cointop-sh/cointop/cointop.(*Cointop).NextPage(0xc000268000)
        D:/workspace/github.com/cointop-sh/cointop/cointop/navigation.go:272 +0x9e
github.com/cointop-sh/cointop/cointop.(*Cointop).Keyfn.func1(0x0, 0x133b480)
        D:/workspace/github.com/cointop-sh/cointop/cointop/keybindings.go:393 +0x22
github.com/cointop-sh/cointop/pkg/gocui.(*Gui).execEventBindings(0xc000332ea0, 0xc00043c7e0, {0x133b480, 0xc0007f25c0})
        D:/workspace/github.com/cointop-sh/cointop/pkg/gocui/gui.go:709 +0xf0
github.com/cointop-sh/cointop/pkg/gocui.(*Gui).onEvent(0xc000332ea0, {0x133b480, 0xc0007f25c0})
        D:/workspace/github.com/cointop-sh/cointop/pkg/gocui/gui.go:649 +0x106
github.com/cointop-sh/cointop/pkg/gocui.(*Gui).handleEvent(0xc0000a1a38, {0x133b480, 0xc0007f25c0})
        D:/workspace/github.com/cointop-sh/cointop/pkg/gocui/gui.go:466 +0xe5
github.com/cointop-sh/cointop/pkg/gocui.(*Gui).MainLoop(0xc000332ea0)
        D:/workspace/github.com/cointop-sh/cointop/pkg/gocui/gui.go:426 +0x146
github.com/cointop-sh/cointop/pkg/ui.(*UI).MainLoop(...)
        D:/workspace/github.com/cointop-sh/cointop/pkg/ui/ui.go:64
github.com/cointop-sh/cointop/cointop.(*Cointop).Run(0xc000268000)
        D:/workspace/github.com/cointop-sh/cointop/cointop/cointop.go:512 +0x2f2
github.com/cointop-sh/cointop/cmd/commands.RootCmd.func1(0xc00023a000, {0x127f174, 0x0, 0x0})
        D:/workspace/github.com/cointop-sh/cointop/cmd/commands/root.go:122 +0x4c7
github.com/spf13/cobra.(*Command).execute(0xc00023a000, {0xc0000881f0, 0x0, 0x0})
        D:/workspace/github.com/cointop-sh/cointop/vendor/github.com/spf13/cobra/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc00023a000)
        D:/workspace/github.com/cointop-sh/cointop/vendor/github.com/spf13/cobra/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        D:/workspace/github.com/cointop-sh/cointop/vendor/github.com/spf13/cobra/command.go:902
github.com/cointop-sh/cointop/cmd/commands.Execute()
        D:/workspace/github.com/cointop-sh/cointop/cmd/commands/cmd.go:22 +0x13a
main.main()
        D:/workspace/github.com/cointop-sh/cointop/main.go:8 +0x17
➜  ~

```