### PR TITLE
Fix conversion key can be triggered in any menu

### DIFF
--- a/cointop/conversion.go
+++ b/cointop/conversion.go
@@ -235,6 +235,10 @@ func (ct *Cointop) SetCurrencyConverstion(convert string) error {
 func (ct *Cointop) SetCurrencyConverstionFn(convert string) func() error {
 	log.Debug("SetCurrencyConverstionFn()")
 	return func() error {
+		if !ct.State.convertMenuVisible {
+			return nil
+		}
+
 		ct.HideConvertMenu()
 
 		if err := ct.SetCurrencyConverstion(convert); err != nil {


### PR DESCRIPTION
The problem is:
**Given** I stay in help menu
**When** I use any key which also been mapping to country currency
**Then** the coin accidentally get convert to the currency

Have fixed by ensure the convert menu is visible, otherwise it shouldn't trigger the convert func.