### PR TITLE
Fix wrong scope of var

### DIFF
--- a/cointop/keybindings.go
+++ b/cointop/keybindings.go
@@ -54,7 +54,7 @@ func (ct *Cointop) ParseKeys(s string) (interface{}, tcell.ModMask) {
 	s = strings.TrimSpace(s)
 	keyName := keyMap(s)
 	if len(s) > 1 {
-		keyName := strings.Replace(s, "+", "-", -1)
+		keyName = strings.Replace(s, "+", "-", -1)
 
 		split := strings.Split(keyName, "-")
 		if len(split) > 1 {
@@ -98,7 +98,7 @@ func (ct *Cointop) ParseKeys(s string) (interface{}, tcell.ModMask) {
 	}
 
 	if key == nil {
-		log.Debugf("Could not map key descriptio '%s' to key", s)
+		log.Debugf("Could not map key '%s' to key", s)
 	}
 	return key, mod
 }

--- a/cointop/keybindings.go
+++ b/cointop/keybindings.go
@@ -51,10 +51,9 @@ func (ct *Cointop) ParseKeys(s string) (interface{}, tcell.ModMask) {
 	mod := tcell.ModNone
 
 	// translate legacy and special names for keys
-	s = strings.TrimSpace(s)
-	keyName := keyMap(s)
-	if len(s) > 1 {
-		keyName = strings.Replace(s, "+", "-", -1)
+	keyName := keyMap(strings.TrimSpace(s))
+	if len(keyName) > 1 {
+		keyName = strings.Replace(keyName, "+", "-", -1)
 
 		split := strings.Split(keyName, "-")
 		if len(split) > 1 {


### PR DESCRIPTION
Still have some logs, haven't found the reason pagedown and pageup couldn't parsed.
```
time="2021-11-23T22:50:49+07:00" level=debug msg="Could not map key 'pagedown' to key"
time="2021-11-23T22:50:49+07:00" level=debug msg="Could not map key 'pageup' to key"
time="2021-11-23T22:50:49+07:00" level=debug msg="Sortfn()"
time="2021-11-23T22:50:49+07:00" level=debug msg="Could not map key 'space' to key"
time="2021-11-23T22:50:49+07:00" level=debug msg="Could not map key '\\\\' to key"
```

Updated: fixed