### PR TITLE
feat(/flake.nix): add a nix flake to facilitate reproducible builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "7e5bf3925",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1638110343,
+        "narHash": "sha256-hQaow8sGPyUrXgrqgDRsfA+73uR0vms2goTQNxIAaRQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "942eb9a335b4cd22fa6a7be31c494e53e76f5637",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      rec {
+        packages = flake-utils.lib.flattenTree {
+          cointop = let lib = pkgs.lib; in
+            pkgs.buildGo117Module {
+              pname = "cointop";
+              version = "1.6.9";
+
+              modSha256 = lib.fakeSha256;
+              vendorSha256 = null;
+
+              src = ./.;
+
+              meta = {
+                description = "A fast and lightweight interactive terminal based UI application for tracking cryptocurrencies 🚀";
+                homepage = "https://cointop.sh/";
+                license = lib.licenses.mit;
+                maintainers = [ "johnrichardrinehart" ]; # flake maintainers, not project maintainers
+                platforms = lib.platforms.linux ++ lib.platforms.darwin;
+              };
+            };
+        };
+
+        defaultPackage = packages.cointop;
+        defaultApp = packages.cointop;
+      }
+    );
+}


### PR DESCRIPTION
# Description
This PR introduces a `flake.nix` to be used with the `nix` build system to help support reproducible builds. Please consider this for your project - it's something like a `Dockerfile` in that including it is low cost, but high benefit.