### PR TITLE
Update install docs for compatible go version

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -15,7 +15,7 @@ Make sure to have [go](https://golang.org/) (1.17+) installed, then do:
 go install github.com/cointop-sh/cointop@latest
 ```
 
-The cointop executable will be under `~/go/bin/cointop` so make sure `$GOPATH/bin` is added to the `$PATH` variable if not already.
+The cointop executable will be under your GOPATH so make sure `$GOPATH/bin` is added to the `$PATH` variable if not already.
 
 Now you can run cointop:
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -9,10 +9,10 @@ There are multiple ways you can install cointop depending on the platform you're
 
 ## From source (always latest and recommended)
 
-Make sure to have [go](https://golang.org/) (1.12+) installed, then do:
+Make sure to have [go](https://golang.org/) (1.17+) installed, then do:
 
 ```bash
-go get github.com/cointop-sh/cointop
+go install github.com/cointop-sh/cointop@latest
 ```
 
 The cointop executable will be under `~/go/bin/cointop` so make sure `$GOPATH/bin` is added to the `$PATH` variable if not already.


### PR DESCRIPTION
I bumped into #260 because I had go version 1.12 on my system. This PR updates the Install docs to list the minimum required go version and also changes the `go get` command to a `go install` per https://go.dev/doc/go-get-install-deprecation.