### PR TITLE
Add token permissions for go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

StepSecurity is working on securing GitHub workflows and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using StepSecurity's secure-workflows online tool [app.stepsecurity.io](https://github.com/cosmos/cosmos-sdk/pull/app.stepsecurity.io) to improve the security of GitHub workflows.

This repository has a Scorecards score of 0/10 in the `Token-Permissions` category with 10 being the most secure.

We have fixed one of the repo's workflow(s) for you by adding permissions for the involved jobs. You can secure the rest of the workflows for improved security by using the StepSecurity online tool at [app.stepsecurity.io](https://app.stepsecurity.io/).