### PR TITLE
Add max_pages parameter to config file

### DIFF
--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -67,7 +67,7 @@ type State struct {
 	keepRowFocusOnSort         bool
 	lastSelectedRowIndex       int
 	marketBarHeight            int
-	maxPages                   int
+	maxPages                   uint
 	page                       int
 	perPage                    int
 	portfolio                  *Portfolio
@@ -282,7 +282,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 			hidePortfolioBalances: config.HidePortfolioBalances,
 			keepRowFocusOnSort:    false,
 			marketBarHeight:       1,
-			maxPages:              int(maxPages),
+			maxPages:              maxPages,
 			onlyTable:             config.OnlyTable,
 			onlyChart:             config.OnlyChart,
 			refreshRate:           60 * time.Second,
@@ -423,7 +423,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 	if ct.apiChoice == CoinMarketCap {
 		ct.api = api.NewCMC(ct.apiKeys.cmc)
 	} else if ct.apiChoice == CoinGecko {
-		ct.api = api.NewCG(perPage, maxPages)
+		ct.api = api.NewCG(perPage, ct.State.maxPages)
 	} else {
 		return nil, ErrInvalidAPIChoice
 	}

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -52,6 +52,7 @@ type ConfigFileConfig struct {
 	CompactNotation   interface{}            `toml:"compact_notation"`
 	EnableMouse       interface{}            `toml:"enable_mouse"`
 	AltCoinLink       interface{}            `toml:"alt_coin_link"` // TODO: should really be in API-specific section
+	MaxPages          interface{}            `toml:"max_pages"`
 	Table             map[string]interface{} `toml:"table"`
 	Chart             map[string]interface{} `toml:"chart"`
 }
@@ -79,6 +80,7 @@ func (ct *Cointop) SetupConfig() error {
 		ct.loadAltCoinLinkFromConfig,
 		ct.loadPriceAlertsFromConfig,
 		ct.loadPortfolioFromConfig,
+		ct.loadMaxPagesFromConfig,
 	}
 
 	for _, f := range loaders {
@@ -302,6 +304,7 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 		CompactNotation:   ct.State.compactNotation,
 		EnableMouse:       ct.State.enableMouse,
 		AltCoinLink:       ct.State.altCoinLink,
+		MaxPages:          ct.State.maxPages,
 	}
 
 	var b bytes.Buffer
@@ -741,6 +744,15 @@ func (ct *Cointop) loadPriceAlertsFromConfig() error {
 			return ErrInvalidPriceAlert
 		}
 		ct.State.priceAlerts.SoundEnabled = enabled
+	}
+
+	return nil
+}
+
+func (ct *Cointop) loadMaxPagesFromConfig() error {
+	log.Debug("loadMaxPagesFromConfig()")
+	if MaxPages, ok := ct.config.MaxPages.(int64); ok {
+		ct.State.maxPages = uint(MaxPages)
 	}
 
 	return nil


### PR DESCRIPTION
This makes it easier to track smaller tokens, or reduce the amount of tokens being tracked. Somewhat fixes #276, until a more refined way of fetching the desired tokens is implemented.